### PR TITLE
fix: update LEDC sleep mode configuration

### DIFF
--- a/main/display_driver.cpp
+++ b/main/display_driver.cpp
@@ -49,7 +49,7 @@ bool DisplayDriver::initialize() {
         .timer_sel = LEDC_TIMER_0,
         .duty = 0,
         .hpoint = 0,
-        .sleep_mode = LEDC_SLEEP_LEV_LOW,
+        .sleep_mode = LEDC_SLEEP_MODE_NO_ALIVE_NO_PD,
         .flags = 0
     };
     ESP_ERROR_CHECK(ledc_channel_config(&ledc_channel));


### PR DESCRIPTION
## Summary
- replace deprecated LEDC_SLEEP_LEV_LOW with LEDC_SLEEP_MODE_NO_ALIVE_NO_PD in display driver to use a valid sleep mode

## Testing
- `idf.py build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4839a060832393c5e913979dec41