### PR TITLE
Handle optional esp_timer initialization

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -5,6 +5,7 @@
 #include "freertos/task.h"
 #include "esp_system.h"
 #include "esp_log.h"
+#include "esp_err.h"
 #include "nvs_flash.h"
 #include "esp_timer.h"
 
@@ -112,7 +113,10 @@ static void initialize_system() {
     initialize_nvs();
     
     // Configuration de l'horloge système pour la précision temporelle
-    esp_timer_init();
+    esp_err_t timer_ret = esp_timer_init();
+    if (timer_ret != ESP_OK && timer_ret != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "esp_timer_init failed: %s", esp_err_to_name(timer_ret));
+    }
     
     // Log des informations système
     esp_chip_info_t chip_info;


### PR DESCRIPTION
## Summary
- guard explicit esp_timer initialization and ignore ESP_ERR_INVALID_STATE
- include esp_err header for error handling

## Testing
- `idf.py --version` *(fails: command not found)*
- `cmake -S . -B build` *(fails: include could not find requested file: /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5945b2048323935cc6871037fcd1