### PR TITLE
Handle null species and name in reptile log

### DIFF
--- a/main/game_engine.cpp
+++ b/main/game_engine.cpp
@@ -69,7 +69,9 @@ bool GameEngine::add_reptile(ReptileSpecies species, const char *name) {
   new_reptile.experience_points = 0;
 
   reptiles.push_back(new_reptile);
-  ESP_LOGI(TAG, "Nouveau reptile ajouté: %s (%s)", name, data.scientific_name);
+  const char *sci = data.scientific_name ? data.scientific_name : "Inconnu";
+  ESP_LOGI(TAG, "Nouveau reptile ajouté: %s (%s)",
+           name ? name : "Sans nom", sci);
   return true;
 }
 


### PR DESCRIPTION
## Summary
- Avoid null pointer logging for reptile names and scientific names by using placeholders

## Testing
- `idf.py build` *(fails: command not found)*
- `idf.py flash` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6126dff48323929ae222c84b3f38