### PR TITLE
Implement missing game engine functions and add unit tests

### DIFF
--- a/main/game_engine.cpp
+++ b/main/game_engine.cpp
@@ -5,6 +5,7 @@
 #include "include/species_database.h"
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 
 static const char *TAG = "GameEngine";
 
@@ -346,4 +347,74 @@ void GameEngine::select_reptile(uint8_t index) {
 
 uint8_t GameEngine::get_selected_reptile() const {
   return selected_reptile_index;
+}
+
+bool GameEngine::remove_reptile(uint8_t index) {
+  if (index >= reptiles.size()) {
+    return false;
+  }
+
+  reptiles.erase(reptiles.begin() + index);
+  if (selected_reptile_index >= reptiles.size()) {
+    selected_reptile_index = reptiles.empty() ? 0 : reptiles.size() - 1;
+  }
+  return true;
+}
+
+bool GameEngine::handle_reptile(uint8_t index) {
+  if (index >= reptiles.size()) {
+    return false;
+  }
+
+  Reptile &reptile = reptiles[index];
+  if (reptile.health.stress_level > 0) {
+    reptile.health.stress_level -= 1;
+  }
+  reptile.experience_points += 1;
+  return true;
+}
+
+bool GameEngine::can_breed(uint8_t female_index, uint8_t male_index) {
+  if (female_index >= reptiles.size() || male_index >= reptiles.size()) {
+    return false;
+  }
+  return false; // Système de reproduction non implémenté
+}
+
+bool GameEngine::initiate_breeding(uint8_t female_index, uint8_t male_index) {
+  (void)female_index;
+  (void)male_index;
+  return false; // Fonctionnalité non disponible
+}
+
+bool GameEngine::treat_health_issue(uint8_t index, const char *treatment) {
+  if (index >= reptiles.size() || treatment == nullptr) {
+    return false;
+  }
+
+  Reptile &reptile = reptiles[index];
+  reptile.health.overall_health =
+      std::min<uint8_t>(100, reptile.health.overall_health + 5);
+  reptile.experience_points += 2;
+  return true;
+}
+
+uint32_t GameEngine::get_total_experience() const {
+  uint32_t total = 0;
+  for (const auto &r : reptiles) {
+    total += r.experience_points;
+  }
+  return total;
+}
+
+uint8_t GameEngine::get_keeper_level() const {
+  return static_cast<uint8_t>(get_total_experience() / 100);
+}
+
+bool GameEngine::save_game_state() {
+  return true;
+}
+
+bool GameEngine::load_game_state() {
+  return true;
 }

--- a/main/include/ui_manager.h
+++ b/main/include/ui_manager.h
@@ -43,7 +43,6 @@ private:
     
     // Méthodes de construction d'interface
     void create_main_screen();
-    void create_reptile_info_display();
     void create_health_monitoring();
     void create_environment_controls();
     void create_feeding_interface();
@@ -51,7 +50,6 @@ private:
     void create_navigation_menu();
     
     // Callbacks d'événements
-    static void on_reptile_select(lv_event_t* e);
     static void on_feed_button(lv_event_t* e);
     static void on_temperature_adjust(lv_event_t* e);
     static void on_humidity_adjust(lv_event_t* e);
@@ -69,30 +67,21 @@ private:
     
     // Animations
     void animate_feeding(lv_obj_t* target);
-    void animate_health_change(lv_obj_t* health_bar, uint8_t new_value);
-    void animate_behavior_transition(Behavior new_behavior);
-    
+
 public:
     UIManager(GameEngine* engine);
     ~UIManager();
-    
+
     bool initialize();
     void update();
-    void handle_touch_input(lv_indev_data_t* data);
-    
+
     // Gestion des écrans
     void switch_to_screen(uint8_t screen_id);
-    void refresh_current_screen();
-    
+
     // Notifications système
     void show_feeding_reminder(const char* reptile_name);
     void show_health_alert(const char* reptile_name, const char* issue);
-    void show_breeding_notification(const char* message);
-    void show_achievement(const char* achievement);
     
-    // Interface tactile optimisée
-    void enable_touch_feedback();
-    void set_screen_brightness(uint8_t brightness);
 };
 
 // IDs des écrans

--- a/tests/game_engine_tests.cpp
+++ b/tests/game_engine_tests.cpp
@@ -1,0 +1,26 @@
+#include "game_engine.h"
+#include "species_database.h"
+#include <iostream>
+
+int main() {
+    GameEngine engine;
+    engine.add_reptile(ReptileSpecies::POGONA_VITTICEPS, "Alpha");
+    engine.add_reptile(ReptileSpecies::LEOPARD_GECKO, "Beta");
+
+    Reptile* r0 = engine.get_reptile(0);
+    Reptile* r1 = engine.get_reptile(1);
+    if (!r0 || !r1) return 1;
+
+    r0->experience_points = 150;
+    r1->experience_points = 50;
+
+    if (engine.get_total_experience() != 200) return 1;
+    if (engine.get_keeper_level() != 2) return 1;
+
+    if (!engine.treat_health_issue(0, "soin")) return 1;
+
+    if (!engine.remove_reptile(0)) return 1;
+    if (engine.get_reptile_count() != 1) return 1;
+    std::cout << "OK" << std::endl;
+    return 0;
+}

--- a/tests/stubs/esp_log.h
+++ b/tests/stubs/esp_log.h
@@ -1,0 +1,4 @@
+#pragma once
+#define ESP_LOGI(tag, fmt, ...)
+#define ESP_LOGW(tag, fmt, ...)
+#define ESP_LOGE(tag, fmt, ...)

--- a/tests/stubs/esp_random.h
+++ b/tests/stubs/esp_random.h
@@ -1,0 +1,3 @@
+#pragma once
+#include <stdint.h>
+static inline uint32_t esp_random(void) { return 4; }

--- a/tests/stubs/esp_timer.h
+++ b/tests/stubs/esp_timer.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <stdint.h>
+static inline uint64_t esp_timer_get_time(void) {
+    static uint64_t t = 0;
+    t += 1000;
+    return t;
+}

--- a/tests/stubs/lvgl.h
+++ b/tests/stubs/lvgl.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <stdint.h>
+typedef int lv_color_t;
+typedef int lv_indev_t;
+typedef int lv_display_t;
+struct lv_area_t { int x1; int y1; int x2; int y2; };


### PR DESCRIPTION
## Summary
- implement minimal versions of previously undefined `GameEngine` methods to handle reptile removal, health treatment, experience tracking and stub persistence
- streamline `UIManager` header by dropping unused declarations
- add host-based unit test and ESP/LVGL stubs verifying basic `GameEngine` behaviour

## Testing
- `g++ -std=c++17 tests/game_engine_tests.cpp main/game_engine.cpp main/reptile_species.cpp -I main/include -I tests/stubs -o tests/game_engine_tests && ./tests/game_engine_tests`


------
https://chatgpt.com/codex/tasks/task_e_68bbf6ca1e18832390a73e17d7f88f4d