### PR TITLE
refactor: default save stats

### DIFF
--- a/main/include/save_system.h
+++ b/main/include/save_system.h
@@ -9,10 +9,10 @@ class GameEngine; // Forward declaration
 
 class SaveSystem {
 private:
-    nvs_handle_t nvs_handle;
-    bool is_initialized;
-    uint32_t save_version;
-    GameEngine* game_engine;
+    nvs_handle_t nvs_handle = 0;
+    bool is_initialized = false;
+    uint32_t save_version = 1;
+    GameEngine* game_engine = nullptr;
     
     // Clés de sauvegarde
     static const char* NVS_NAMESPACE;
@@ -72,14 +72,14 @@ public:
     
     // Statistiques
     struct SaveStats {
-        uint32_t total_saves;
-        uint32_t successful_saves;
-        uint32_t failed_saves;
-        uint32_t last_save_duration_ms;
-        size_t save_data_size;
+        uint32_t total_saves = 0;
+        uint32_t successful_saves = 0;
+        uint32_t failed_saves = 0;
+        uint32_t last_save_duration_ms = 0;
+        size_t save_data_size = 0;
     };
 
-    SaveStats statistics;
+    SaveStats statistics{};
 
     SaveStats get_save_statistics() const;
 };

--- a/main/save_system.cpp
+++ b/main/save_system.cpp
@@ -24,8 +24,7 @@ const char* SaveSystem::KEY_LAST_SAVE_TIME_BACKUP = "last_save_bak";
 #define SAVE_DATA_MAGIC 0x52455054
 
 SaveSystem::SaveSystem(GameEngine* engine)
-    : nvs_handle(0), is_initialized(false), save_version(CURRENT_SAVE_VERSION),
-      game_engine(engine), statistics{0} {}
+    : game_engine(engine), statistics{} {}
 
 SaveSystem::~SaveSystem() {
     if (is_initialized) {


### PR DESCRIPTION
## Summary
- simplify SaveSystem constructor to rely on in-class member defaults
- add zero-initialized defaults for SaveStats metrics
- provide default initialization for SaveSystem state fields

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file: /tools/cmake/project.cmake)*


------
https://chatgpt.com/codex/tasks/task_e_68bc12f17b648323be8a39e4a1d4b813